### PR TITLE
Update requirements.txt - comment unused packages, allow newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-psycopg2-binary==2.9.1
-numpy==1.21.2
-pandas==1.3.3
-logger==1.4
-sqlalchemy==1.4.25
-pyodbc==4.0.32
-configparser==5.0.2
-importlib==1.0.4
-requests==2.26.0
-rpy2==3.4.5
+psycopg2-binary>=2.9.1
+numpy>=1.21.2
+pandas>=1.3.3
+# logger==1.4
+sqlalchemy>=1.4.25
+# pyodbc==4.0.32
+# configparser==5.0.2
+# importlib==1.0.4
+# requests==2.26.0
+rpy2>=3.4.5


### PR DESCRIPTION
I had trouble getting the package up and working because my version of Python (3.11) was too new for some of the package versions defined in requirements.txt. I updated the file to allow versions at the defined version or newer and everything I have tested works with the latest versions of these packages. However, not convinced this is best practice for a requirements.txt file.

I also commented out packages I found to be not required for the current features of fitzRoyPy. Maybe there was a reason these were included initially? For example, importlib is not standard lib in Python 3.0, is that why this was originally included?